### PR TITLE
Dense stereo depth publisher

### DIFF
--- a/src/slamware_ros_sdk/src/server/server_workers.h
+++ b/src/slamware_ros_sdk/src/server/server_workers.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "server_worker_base.h"
@@ -284,6 +283,7 @@ namespace slamware_ros_sdk
         // Depth camera publishers
         ros::Publisher pubDepthImage_;
         ros::Publisher pubDepthColorized_;
+        ros::Publisher pubDensePointCloud_;  // colored PointCloud2 from POINT3D frame
         
         // Semantic segmentation publishers
         ros::Publisher pubSemanticSegmentation_;


### PR DESCRIPTION
I've looked at the demos mentioned in https://github.com/Slamtec/aurora_ros/issues/6 and while the dumped intrinsics weren't useful, the depth image to PLY exporter was a working example on how to turn it into a pointcloud, so here's an implemented publisher for it.

Haven't tested it much yet, but it seems to align at first glance. I've swapped the nonexisting `camera_depth_optical_frame` for `camera_left`, I suggest changing that back if anyone ever figures out where that link is supposed to be.

<img width="2844" height="1519" alt="image" src="https://github.com/user-attachments/assets/186ee8b9-7626-43c9-bb50-a0570cdf7a49" />

<img width="2565" height="1349" alt="image" src="https://github.com/user-attachments/assets/30547ec2-598a-4447-84d8-515f918364dc" />
